### PR TITLE
Add function CleanupOldScratchFiles symmetrically

### DIFF
--- a/fs_mgr/fs_mgr_overlayfs.cpp
+++ b/fs_mgr/fs_mgr_overlayfs.cpp
@@ -115,6 +115,9 @@ namespace fs_mgr {
 
 void MapScratchPartitionIfNeeded(Fstab*,
                                  const std::function<bool(const std::set<std::string>&)>&) {}
+
+void CleanupOldScratchFiles() {}
+
 }  // namespace fs_mgr
 }  // namespace android
 


### PR DESCRIPTION
For symmetry, add function CleanupOldScratchFiles in conditional compilation blocks which missing it.

Test: monkey test for one day and one night

Signed-off-by: Jintao Zhu <zhujtcsieee@gmail.com>

Change-Id: Ie754427334c9a9bb7cfed70df45f439c60c9ab16