### PR TITLE
support 0/1 values of persist.native_debug (ptrace) sysprop

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -1239,6 +1239,12 @@ on property:persist.native_debug=true
 on property:persist.native_debug=false
     write /proc/sys/kernel/yama/ptrace_scope 2
 
+on property:persist.native_debug=1
+    write /proc/sys/kernel/yama/ptrace_scope 0
+
+on property:persist.native_debug=0
+    write /proc/sys/kernel/yama/ptrace_scope 2
+
 # perf_event_open syscall security:
 # Newer kernels have the ability to control the use of the syscall via SELinux
 # hooks. init tests for this, and sets sys_init.perf_lsm_hooks to 1 if the


### PR DESCRIPTION
It's simpler to listen for them here than to modify ExtSettings code to conditionally write false/true instead of 0/1.