### PR TITLE
Revert "add a property for controlling ptrace_scope"

### DIFF
--- a/rootdir/init.rc
+++ b/rootdir/init.rc
@@ -1264,18 +1264,6 @@ on property:persist.security.deny_new_usb=dynamic
 on property:security.deny_new_usb=*
     write /proc/sys/kernel/deny_new_usb ${security.deny_new_usb}
 
-on property:persist.native_debug=true
-    write /proc/sys/kernel/yama/ptrace_scope 0
-
-on property:persist.native_debug=false
-    write /proc/sys/kernel/yama/ptrace_scope 2
-
-on property:persist.native_debug=1
-    write /proc/sys/kernel/yama/ptrace_scope 0
-
-on property:persist.native_debug=0
-    write /proc/sys/kernel/yama/ptrace_scope 2
-
 # perf_event_open syscall security:
 # Newer kernels have the ability to control the use of the syscall via SELinux
 # hooks. init tests for this, and sets sys_init.perf_lsm_hooks to 1 if the


### PR DESCRIPTION
This reverts commit c924d8dc583f427e05c724372f42d06a6cecaa25.

ptrace() access in now controlled per-app via selinux_flags.