### PR TITLE
make persist.adb.tls_server.enable system property non-persistent

### DIFF
--- a/init/property_service.cpp
+++ b/init/property_service.cpp
@@ -1402,6 +1402,10 @@ static void HandleInitSocket() {
             // Read persistent properties after all default values have been loaded.
             auto persistent_properties = LoadPersistentProperties();
             for (const auto& persistent_property_record : persistent_properties.properties()) {
+                if (persistent_property_record.name() == "persist.adb.tls_server.enable") {
+                    continue;
+                }
+
                 InitPropertySet(persistent_property_record.name(),
                                 persistent_property_record.value());
             }


### PR DESCRIPTION
persist.adb.tls_server.enable sysprop enables persistent network ADB, which severely weakens verified boot.

Network ADB is disabled after each reboot by the system_server, but in a fragile way, see frameworks/base/services/core/java/com/android/server/adb/AdbService.java

It's not clear whether this system_server behavior is intentional.