### PR TITLE
fastboot: add optimize-factory-image command

### DIFF
--- a/fastboot/fastboot.h
+++ b/fastboot/fastboot.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <functional>
+#include <map>
 #include <memory>
 #include <string>
 #include "fastboot_driver_interface.h"
@@ -41,6 +42,7 @@
 #include "socket.h"
 #include "util.h"
 #include "ziparchive/zip_archive.h"
+#include "ziparchive/zip_writer.h"
 
 class FastBootTool {
   public:
@@ -193,3 +195,68 @@ bool is_logical(const std::string& partition);
 void fb_perform_format(const std::string& partition, int skip_if_not_supported,
                        const std::string& type_override, const std::string& size_override,
                        const unsigned fs_options, const FlashingPlan* fp);
+
+class FlashCapturer {
+  public:
+    FlashCapturer() = default;
+    void Run(FlashingPlan* flashing_plan, std::string& factory_path, std::string& out_path);
+
+    void SetPendingPartitionName(const std::string& part_name);
+    void AddPartition(const void* data, size_t len, size_t flags = ZipWriter::kCompress);
+    void AddSparsePartition(struct sparse_file *s, size_t flags = ZipWriter::kCompress);
+    void AddSplitSparsePartition(const std::string& name, std::vector<SparsePtr>& files, size_t flags = ZipWriter::kCompress);
+    void AddFile(const std::string& name, const void* data, size_t len, size_t flags = ZipWriter::kCompress);
+
+    void AddCommand(const std::string& cmd);
+    void AddComment(const std::string& comment);
+
+    const std::map<std::string, std::string> vars_ = {
+            {"current-slot", "a"},
+            {"has-slot:boot", "yes"},
+            {"has-slot:dtbo", "yes"},
+            {"has-slot:init_boot", "yes"},
+            {"has-slot:product", "yes"},
+            {"has-slot:pvmfw", "yes"},
+            {"has-slot:super", "no"},
+            {"has-slot:system", "yes"},
+            {"has-slot:system_dlkm", "yes"},
+            {"has-slot:system_ext", "yes"},
+            {"has-slot:vbmeta", "yes"},
+            {"has-slot:vbmeta_system", "yes"},
+            {"has-slot:vbmeta_vendor", "yes"},
+            {"has-slot:vendor", "yes"},
+            {"has-slot:vendor_boot", "yes"},
+            {"has-slot:vendor_dlkm", "yes"},
+            {"has-slot:vendor_kernel_boot", "yes"},
+            {"is-logical:boot_a", "no"},
+            {"is-logical:dtbo_a", "no"},
+            {"is-logical:init_boot_a", "no"},
+            {"is-logical:product_a", "yes"},
+            {"is-logical:pvmfw_a", "no"},
+            {"is-logical:super", "no"},
+            {"is-logical:system_a", "yes"},
+            {"is-logical:system_dlkm_a", "yes"},
+            {"is-logical:system_ext_a", "yes"},
+            {"is-logical:vbmeta_a", "no"},
+            {"is-logical:vbmeta_system_a", "no"},
+            {"is-logical:vbmeta_vendor_a", "no"},
+            {"is-logical:vendor_a", "yes"},
+            {"is-logical:vendor_boot_a", "no"},
+            {"is-logical:vendor_dlkm_a", "yes"},
+            {"is-logical:vendor_kernel_boot_a", "no"},
+            {"slot-count", "2"},
+            {"super-partition-name", "super"},
+    };
+
+  private:
+    void AddSparseFileInner(struct sparse_file *s, const std::string &name, size_t flags);
+
+    std::string* pending_file_name_{};
+    std::string script_;
+
+    FILE* output_zip_writer_file_{};
+    ZipWriter* output_zip_writer_{};
+};
+
+FlashCapturer* flash_capturer();
+bool has_flash_capturer();

--- a/fastboot/task.cpp
+++ b/fastboot/task.cpp
@@ -124,11 +124,18 @@ void OptimizedFlashSuperTask::Run() {
     if (int limit = get_sparse_limit(super_size_, fp_)) {
         files = resparse_file(sparse_layout_.get(), limit);
     } else {
+        if (has_flash_capturer()) {
+            die("unexpected sparse limit %i", limit);
+        }
         files.emplace_back(std::move(sparse_layout_));
     }
 
-    // Send the data to the device.
-    flash_partition_files(super_name_, files);
+    if (auto fc = flash_capturer()) {
+        fc->AddSplitSparsePartition("super", files);
+    } else {
+        // Send the data to the device.
+        flash_partition_files(super_name_, files);
+    }
 }
 
 std::string OptimizedFlashSuperTask::ToString() const {
@@ -192,15 +199,19 @@ std::unique_ptr<OptimizedFlashSuperTask> OptimizedFlashSuperTask::Initialize(
         super_name = "super";
     }
     uint64_t partition_size;
-    std::string partition_size_str;
-    if (fp->fb->GetVar("partition-size:" + super_name, &partition_size_str) != fastboot::SUCCESS) {
-        LOG(VERBOSE) << "Cannot optimize super flashing: could not determine super partition";
-        return nullptr;
-    }
-    partition_size_str = fb_fix_numeric_var(partition_size_str);
-    if (!android::base::ParseUint(partition_size_str, &partition_size)) {
-        LOG(VERBOSE) << "Could not parse " << super_name << " size: " << partition_size_str;
-        return nullptr;
+    if (has_flash_capturer()) {
+        partition_size = fp->sparse_limit + 1;
+    } else {
+        std::string partition_size_str;
+        if (fp->fb->GetVar("partition-size:" + super_name, &partition_size_str) != fastboot::SUCCESS) {
+            LOG(VERBOSE) << "Cannot optimize super flashing: could not determine super partition";
+            return nullptr;
+        }
+        partition_size_str = fb_fix_numeric_var(partition_size_str);
+        if (!android::base::ParseUint(partition_size_str, &partition_size)) {
+            LOG(VERBOSE) << "Could not parse " << super_name << " size: " << partition_size_str;
+            return nullptr;
+        }
     }
 
     std::unique_ptr<SuperFlashHelper> helper = std::make_unique<SuperFlashHelper>(*fp->source);
@@ -297,6 +308,11 @@ std::string DeleteTask::ToString() const {
 WipeTask::WipeTask(const FlashingPlan* fp, const std::string& pname) : fp_(fp), pname_(pname){};
 
 void WipeTask::Run() {
+    if (auto fc = flash_capturer()) {
+        fc->AddCommand("erase " + pname_);
+        return;
+    }
+
     std::string partition_type;
     if (fp_->fb->GetVar("partition-type:" + pname_, &partition_type) != fastboot::SUCCESS) {
         LOG(ERROR) << "wipe task partition not found: " << pname_;


### PR DESCRIPTION
optimize-factory-image command captures commands that fastboot issues during flashing of the update zip (which is nested in factory image zip) to the script.txt file. Partition images and script.txt are copied to the output optimized factory image zip. flash-all.sh commands are parsed manually.

Optimized factory image zip is intended to be used by the fastboot.js-based web installer.

Main advantages of using optimized factory images instead of standard images in fastboot.js:
- code for creating optimized super partition image on the fly is reused, which removes the need to use fastbootd during flashing. fastbootd currently requires manual driver installation on Windows.
- lowering of install-time storage and memory requirements
- simplification of fastboot.js code
- consistency between fastboot and fastboot.js flashing sequence