### PR TITLE
don't disable external ports at boot on debuggable builds

### DIFF
--- a/init/Android.bp
+++ b/init/Android.bp
@@ -105,6 +105,7 @@ libinit_cc_defaults {
         misc_undefined: ["signed-integer-overflow"],
     },
     cflags: [
+        "-DDISABLE_EXTERNAL_PORTS_ON_NORMAL_BOOT=1",
         "-DALLOW_FIRST_STAGE_CONSOLE=0",
         "-DALLOW_LOCAL_PROP_OVERRIDE=0",
         "-DALLOW_PERMISSIVE_SELINUX=0",
@@ -125,6 +126,9 @@ libinit_cc_defaults {
     product_variables: {
         debuggable: {
             cppflags: [
+                "-UDISABLE_EXTERNAL_PORTS_ON_NORMAL_BOOT",
+                // USB adb access is needed for debugging early boot failures
+                "-DDISABLE_EXTERNAL_PORTS_ON_NORMAL_BOOT=0",
                 "-UALLOW_FIRST_STAGE_CONSOLE",
                 "-DALLOW_FIRST_STAGE_CONSOLE=1",
                 "-UALLOW_LOCAL_PROP_OVERRIDE",
@@ -406,6 +410,7 @@ init_first_stage_cc_defaults {
         "-Wextra",
         "-Wno-unused-parameter",
         "-Werror",
+        "-DDISABLE_EXTERNAL_PORTS_ON_NORMAL_BOOT=1",
         "-DALLOW_FIRST_STAGE_CONSOLE=0",
         "-DALLOW_LOCAL_PROP_OVERRIDE=0",
         "-DALLOW_PERMISSIVE_SELINUX=0",
@@ -420,6 +425,10 @@ init_first_stage_cc_defaults {
     product_variables: {
         debuggable: {
             cflags: [
+                "-UDISABLE_EXTERNAL_PORTS_ON_NORMAL_BOOT",
+                // USB adb access is needed for debugging early boot failures
+                "-DDISABLE_EXTERNAL_PORTS_ON_NORMAL_BOOT=0",
+
                 "-UALLOW_FIRST_STAGE_CONSOLE",
                 "-DALLOW_FIRST_STAGE_CONSOLE=1",
 

--- a/init/first_stage_init.cpp
+++ b/init/first_stage_init.cpp
@@ -450,7 +450,7 @@ int FirstStageMain(int argc, char** argv) {
     boot_clock::time_point module_start_time = boot_clock::now();
     int module_count = 0;
     BootMode boot_mode = GetBootMode(cmdline, bootconfig);
-    bool disable_external_ports = boot_mode == BootMode::NORMAL_MODE;
+    bool disable_external_ports = boot_mode == BootMode::NORMAL_MODE && DISABLE_EXTERNAL_PORTS_ON_NORMAL_BOOT;
     if (!LoadKernelModules(boot_mode, want_console,
                            want_parallel, disable_external_ports, module_count)) {
         if (want_console != FirstStageConsoleParam::DISABLED) {

--- a/init/first_stage_init.cpp
+++ b/init/first_stage_init.cpp
@@ -211,7 +211,7 @@ std::string GetModuleLoadList(BootMode boot_mode, const std::string& dir_path) {
 }
 
 #define MODULE_BASE_DIR "/lib/modules"
-bool LoadKernelModules(BootMode boot_mode, bool want_console, bool want_parallel, bool disable_usb_port,
+bool LoadKernelModules(BootMode boot_mode, bool want_console, bool want_parallel, bool disable_external_ports,
                        int& modules_loaded) {
     struct utsname uts{};
     if (uname(&uts)) {
@@ -269,7 +269,7 @@ bool LoadKernelModules(BootMode boot_mode, bool want_console, bool want_parallel
     for (const auto& module_dir : module_dirs) {
         std::string dir_path = MODULE_BASE_DIR "/";
         dir_path.append(module_dir);
-        Modprobe m({dir_path}, GetModuleLoadList(boot_mode, dir_path), true, disable_usb_port);
+        Modprobe m({dir_path}, GetModuleLoadList(boot_mode, dir_path), true, disable_external_ports);
         bool retval = m.LoadListedModules(!want_console);
         modules_loaded = m.GetModuleCount();
         if (modules_loaded > 0) {
@@ -278,14 +278,14 @@ bool LoadKernelModules(BootMode boot_mode, bool want_console, bool want_parallel
         }
     }
 
-    if (disable_usb_port) {
+    if (disable_external_ports) {
         if (auto res = WriteFile("/proc/sys/kernel/deny_new_usb2", "1"); res.ok()) {
             LOG(INFO) << "wrote 1 to deny_new_usb2";
         } else {
             LOG(ERROR) << "write to deny_new_usb2 failed";
         }
     }
-    Modprobe m({MODULE_BASE_DIR}, GetModuleLoadList(boot_mode, MODULE_BASE_DIR), true, disable_usb_port);
+    Modprobe m({MODULE_BASE_DIR}, GetModuleLoadList(boot_mode, MODULE_BASE_DIR), true, disable_external_ports);
     bool retval = (want_parallel) ? m.LoadModulesParallel(std::thread::hardware_concurrency())
                                   : m.LoadListedModules(!want_console);
     modules_loaded = m.GetModuleCount();
@@ -450,9 +450,9 @@ int FirstStageMain(int argc, char** argv) {
     boot_clock::time_point module_start_time = boot_clock::now();
     int module_count = 0;
     BootMode boot_mode = GetBootMode(cmdline, bootconfig);
-    bool disable_usb_port = boot_mode == BootMode::NORMAL_MODE;
+    bool disable_external_ports = boot_mode == BootMode::NORMAL_MODE;
     if (!LoadKernelModules(boot_mode, want_console,
-                           want_parallel, disable_usb_port, module_count)) {
+                           want_parallel, disable_external_ports, module_count)) {
         if (want_console != FirstStageConsoleParam::DISABLED) {
             LOG(ERROR) << "Failed to load kernel modules, starting console";
         } else {

--- a/libmodprobe/include/modprobe/modprobe.h
+++ b/libmodprobe/include/modprobe/modprobe.h
@@ -29,7 +29,7 @@
 class Modprobe {
   public:
     Modprobe(const std::vector<std::string>&, const std::string load_file = "modules.load",
-             bool use_blocklist = true, bool disable_usb_port = false);
+             bool use_blocklist = true, bool disable_external_ports = false);
 
     bool LoadModulesParallel(int num_threads);
     bool LoadListedModules(bool strict = true);

--- a/libmodprobe/libmodprobe.cpp
+++ b/libmodprobe/libmodprobe.cpp
@@ -377,7 +377,7 @@ void Modprobe::ParseKernelCmdlineOptions(void) {
 }
 
 Modprobe::Modprobe(const std::vector<std::string>& base_paths, const std::string load_file,
-                   bool use_blocklist, bool disable_usb_port)
+                   bool use_blocklist, bool disable_external_ports)
     : blocklist_enabled(use_blocklist) {
     using namespace std::placeholders;
 
@@ -403,7 +403,7 @@ Modprobe::Modprobe(const std::vector<std::string>& base_paths, const std::string
 
     ParseKernelCmdlineOptions();
 
-    if (disable_usb_port) {
+    if (disable_external_ports) {
         AddOption("tcpci_max77759", "disable_cc_toggling_by_default", "1");
         AddOption("pogo_transport", "charging_only_by_default", "1");
     }


### PR DESCRIPTION
USB adb access is needed for debugging early boot failures.