### PR TITLE
[backport]: libsnapshot: Require snapuserd in CreateUpdateSnapshots().

### DIFF
--- a/fs_mgr/TEST_MAPPING
+++ b/fs_mgr/TEST_MAPPING
@@ -23,9 +23,6 @@
       "name": "vts_libsnapshot_test"
     },
     {
-      "name": "vab_legacy_tests"
-    },
-    {
       "name": "cow_api_test"
     }
   ],
@@ -40,9 +37,6 @@
     },
     {
       "name": "liblp_test"
-    },
-    {
-      "name": "vab_legacy_tests"
     },
     {
       "name": "snapuserd_test"

--- a/fs_mgr/libsnapshot/Android.bp
+++ b/fs_mgr/libsnapshot/Android.bp
@@ -168,9 +168,6 @@ cc_library_static {
     ],
     srcs: [":libsnapshot_sources"],
     recovery_available: true,
-    cflags: [
-        "-DLIBSNAPSHOT_NO_COW_WRITE",
-    ],
     static_libs: [
         "libfs_mgr",
     ],
@@ -314,31 +311,6 @@ cc_test {
     ],
     compile_multilib: "first",
     test_options: {
-        min_shipping_api_level: 30,
-        test_runner_options: [
-            {
-                name: "force-no-test-error",
-                value: "false",
-            },
-        ],
-    },
-}
-
-cc_test {
-    name: "vab_legacy_tests",
-    defaults: [
-        "libsnapshot_test_defaults",
-        "libsnapshot_hal_deps",
-    ],
-    cppflags: [
-        "-DLIBSNAPSHOT_TEST_VAB_LEGACY",
-    ],
-    test_suites: [
-        "general-tests",
-    ],
-    compile_multilib: "64",
-    test_options: {
-        // Legacy VAB launched in Android R.
         min_shipping_api_level: 30,
         test_runner_options: [
             {

--- a/fs_mgr/libsnapshot/snapshot.cpp
+++ b/fs_mgr/libsnapshot/snapshot.cpp
@@ -510,10 +510,16 @@ Return SnapshotManager::CreateCowImage(LockedFile* lock, const std::string& name
         return Return::Error();
     }
 
+    if (device_->IsRecovery()) {
+        LOG(ERROR) << "Cannot create /data backed snapshots in recovery.";
+        return Return::NoSpace(status.cow_file_size());
+    }
+
     std::string cow_image_name = GetCowImageDeviceName(name);
     int cow_flags = IImageManager::CREATE_IMAGE_DEFAULT;
     return Return(images_->CreateBackingImage(cow_image_name, status.cow_file_size(), cow_flags));
 }
+
 static std::optional<std::string> GetUblkControlDevicePath(const std::string& ublkb_path) {
     if (!android::base::StartsWith(ublkb_path, "/dev/block/ublkb")) {
         return std::nullopt;
@@ -3906,8 +3912,6 @@ Return SnapshotManager::CreateUpdateSnapshots(const DeltaArchiveManifest& manife
     std::string vabc_disable_reason;
     if (!dap_metadata.vabc_enabled()) {
         vabc_disable_reason = "not enabled metadata";
-    } else if (device_->IsRecovery()) {
-        vabc_disable_reason = "recovery";
     } else if (!KernelSupportsCompressedSnapshots()) {
         vabc_disable_reason = "kernel missing userspace block device support";
     }
@@ -3946,7 +3950,8 @@ Return SnapshotManager::CreateUpdateSnapshots(const DeltaArchiveManifest& manife
 
     const bool using_snapuserd = userspace_snapshots || legacy_compression;
     if (!using_snapuserd) {
-        LOG(INFO) << "Using legacy Virtual A/B (dm-snapshot)";
+        LOG(ERROR) << "Using legacy Virtual A/B (dm-snapshot)";
+        return Return::Error();
     }
 
     std::string compression_algorithm;


### PR DESCRIPTION
Previously, we forced recovery to use traditional dm-snapshot writes in update_engine. Instead, allow snapuserd in recovery, and forbid dm-snapshot entirely.

This change also turns down the vab_legacy_test suite, and improves CreateUpdateSnapshot() failure logging in recovery.

Bug: 416748567
Test: atest RecoveryOtaTest
Change-Id: If1565e20e19248027d019ee9591e0b088a06cac8